### PR TITLE
Cart total will return 0 when empty

### DIFF
--- a/lib/cartman/cart.rb
+++ b/lib/cartman/cart.rb
@@ -60,7 +60,7 @@ module Cartman
     def total
       items.collect { |item|
         (item.cost * 100).to_i
-      }.inject{|sum,cost| sum += cost} / 100.0
+      }.inject(0){|sum,cost| sum += cost} / 100.0
     end
 
     def ttl

--- a/spec/cart_spec.rb
+++ b/spec/cart_spec.rb
@@ -168,6 +168,10 @@ describe Cartman do
     end
 
     describe "#total" do
+      it "should return 0 when no items are in the cart" do
+        cart.total.should eq(0)
+      end
+
       it "should total the default costs field" do
         cart.add_item(id: 17, type: "Bottle", name: "Bordeux", unit_cost: 92.12, quantity: 2)
         cart.add_item(id: 34, type: "Bottle", name: "Cabernet", unit_cost: 92.12, quantity: 2)


### PR DESCRIPTION
Currently if we call cart.total when the cart is empty and error is thrown. This fix will have total return 0 in the cart is empty.
