### PR TITLE
Use BigDecimal as opposed to floats

### DIFF
--- a/lib/cartman.rb
+++ b/lib/cartman.rb
@@ -1,3 +1,4 @@
+require "bigdecimal"
 require "cartman/version"
 require "cartman/configuration"
 require "cartman/cart"

--- a/lib/cartman/cart.rb
+++ b/lib/cartman/cart.rb
@@ -59,8 +59,8 @@ module Cartman
 
     def total
       items.collect { |item|
-        (item.cost * 100).to_i
-      }.inject(0){|sum,cost| sum += cost} / 100.0
+        item.cost
+      }.inject(BigDecimal("0")){|sum,cost| sum += cost}
     end
 
     def ttl

--- a/lib/cartman/item.rb
+++ b/lib/cartman/item.rb
@@ -11,9 +11,9 @@ module Cartman
     end
 
     def cost
-      unit_cost = (@data.fetch(Cartman.config.unit_cost_field).to_f * 100).to_i
+      unit_cost = BigDecimal(@data.fetch(Cartman.config.unit_cost_field))
       quantity = @data.fetch(Cartman.config.quantity_field).to_i
-      (unit_cost * quantity) / 100.0
+      (unit_cost * quantity)
     end
 
     def cart


### PR DESCRIPTION
Converted Item.cost and cart.total to use BigDecimal as opposed to floats. 

A simple example of how floats will fail: Add an item with a unit cost of $2.30. When you call cart.total you will get 2.29. 
