### PR TITLE
PAT-2009 redis deprecation silence

### DIFF
--- a/lib/cartman.rb
+++ b/lib/cartman.rb
@@ -1,3 +1,4 @@
+require "bigdecimal"
 require "cartman/version"
 require "cartman/configuration"
 require "cartman/cart"

--- a/lib/cartman/cart.rb
+++ b/lib/cartman/cart.rb
@@ -59,8 +59,8 @@ module Cartman
 
     def total
       items.collect { |item|
-        (item.cost * 100).to_i
-      }.inject(0){|sum,cost| sum += cost} / 100.0
+        item.cost
+      }.inject(BigDecimal("0")){|sum,cost| sum += cost}
     end
 
     def ttl

--- a/lib/cartman/cart.rb
+++ b/lib/cartman/cart.rb
@@ -2,8 +2,11 @@ module Cartman
   class Cart
     CART_LINE_ITEM_ID_KEY = "cartman:line_item:id"
 
-    def initialize(uid)
+    attr_reader :discounted
+
+    def initialize(uid, discounted = false)
       @uid = uid
+      @discounted = redis.get(discounted_key) || discounted
     end
 
     def add_item(options)
@@ -118,10 +121,19 @@ module Cartman
       "cart/#{@uid}-#{version}"
     end
 
+    def set_discounted(value)
+      redis.set discounted_key, value
+      @discounted = value
+    end
+
     private
 
     def key(id=@uid)
       "cartman:cart:#{id}"
+    end
+
+    def discounted_key(id=@uid)
+      "cartman:cart:#{id}:discounted"
     end
 
     def index_key(id=@uid)

--- a/lib/cartman/configuration.rb
+++ b/lib/cartman/configuration.rb
@@ -12,7 +12,10 @@ module Cartman
     end
 
     def redis
-      @redis ||= Redis.new
+      @redis ||= begin
+        Redis.silence_deprecations
+        Redis.new
+      end
     end
   end
 end

--- a/lib/cartman/item.rb
+++ b/lib/cartman/item.rb
@@ -11,9 +11,9 @@ module Cartman
     end
 
     def cost
-      unit_cost = (@data.fetch(Cartman.config.unit_cost_field).to_f * 100).to_i
+      unit_cost = BigDecimal(@data.fetch(Cartman.config.unit_cost_field))
       quantity = @data.fetch(Cartman.config.quantity_field).to_i
-      (unit_cost * quantity) / 100.0
+      (unit_cost * quantity)
     end
 
     def cart

--- a/spec/cart_spec.rb
+++ b/spec/cart_spec.rb
@@ -9,6 +9,18 @@ describe Cartman do
       Cartman.config.redis.flushdb
     end
 
+    describe "#set_discounted" do
+      it "sets new value for discounted" do
+        cart.set_discounted true
+        cart.discounted.should be_truthy
+      end
+
+      it "sets new redis value in redis" do
+        cart.set_discounted true
+        Cartman.config.redis.get(cart.send(:discounted_key)).should be_truthy
+      end
+    end
+
     describe "#key" do
       it "should return a proper key string" do
         cart.send(:key).should eq("cartman:cart:1")
@@ -21,11 +33,11 @@ describe Cartman do
       end
 
       it "creates a line item key" do
-        Cartman.config.redis.exists("cartman:line_item:1").should be_true
+        Cartman.config.redis.exists("cartman:line_item:1").should be_truthy
       end
 
       it "adds that line item key's id to the cart set" do
-        Cartman.config.redis.sismember(cart.send(:key), 1).should be_true
+        Cartman.config.redis.sismember(cart.send(:key), 1).should be_truthy
       end
 
       it "should expire the line_item_keys in the amount of time specified" do
@@ -34,8 +46,8 @@ describe Cartman do
       end
 
       it "should add an index key to be able to look up by type and ID" do
-        Cartman.config.redis.exists("cartman:cart:1:index").should be_true
-        Cartman.config.redis.sismember("cartman:cart:1:index", "Bottle:17").should be_true
+        Cartman.config.redis.exists("cartman:cart:1:index").should be_truthy
+        Cartman.config.redis.sismember("cartman:cart:1:index", "Bottle:17").should be_truthy
       end
 
       it "should squack if type and/or ID are not set" do
@@ -55,18 +67,18 @@ describe Cartman do
         item = cart.add_item(id: 17, type: "Bottle", name: "Bordeux", unit_cost: 92.12, quantity: 2)
         item_id = item._id
         cart.remove_item(item)
-        Cartman.config.redis.sismember(cart.send(:key), item_id).should be_false
-        Cartman.config.redis.exists("cartman:line_item:#{item_id}").should be_false
+        Cartman.config.redis.sismember(cart.send(:key), item_id).should be_falsey
+        Cartman.config.redis.exists("cartman:line_item:#{item_id}").should be_falsey
       end
 
       it "should not delete the indecies for other items" do
         item = cart.add_item(id: 17, type: "Bottle", name: "Bordeux", unit_cost: 92.12, quantity: 2)
         item2 = cart.add_item(id: 18, type: "Bottle", name: "Bordeux", unit_cost: 92.12, quantity: 2)
-        Cartman.config.redis.exists("cartman:cart:1:index:Bottle:17").should be_true
-        Cartman.config.redis.exists("cartman:cart:1:index:Bottle:18").should be_true
+        Cartman.config.redis.exists("cartman:cart:1:index:Bottle:17").should be_truthy
+        Cartman.config.redis.exists("cartman:cart:1:index:Bottle:18").should be_truthy
         cart.remove_item(item)
-        Cartman.config.redis.exists("cartman:cart:1:index:Bottle:17").should be_false
-        Cartman.config.redis.exists("cartman:cart:1:index:Bottle:18").should be_true
+        Cartman.config.redis.exists("cartman:cart:1:index:Bottle:17").should be_falsey
+        Cartman.config.redis.exists("cartman:cart:1:index:Bottle:18").should be_truthy
       end
     end
 
@@ -106,18 +118,18 @@ describe Cartman do
       end
 
       it "should be able to tell you that an item in the cart is present" do
-        cart.contains?(Bottle.new(17)).should be_true
+        cart.contains?(Bottle.new(17)).should be_truthy
       end
 
       it "should be able to tell you that an item in the cart is absent" do
-        cart.contains?(Bottle.new(20)).should be_false
+        cart.contains?(Bottle.new(20)).should be_falsey
       end
 
       it "should be able to tell you that an item in the cart is absent if it's been removed" do
         cart.remove_item(cart.items.first)
-        cart.contains?(Bottle.new(17)).should be_false
+        cart.contains?(Bottle.new(17)).should be_falsey
         cart.remove_item(cart.items.last)
-        cart.contains?(Bottle.new(34)).should be_false
+        cart.contains?(Bottle.new(34)).should be_falsey
       end
     end
 
@@ -196,11 +208,11 @@ describe Cartman do
         cart.add_item(id: 17, type: "Bottle", name: "Bordeux", unit_cost: 92.12, cost_in_cents: 18424, quantity: 2)
         cart.add_item(id: 34, type: "Bottle", name: "Cabernet", unit_cost: 92.12, cost_in_cents: 18424, quantity: 2)
         cart.destroy!
-        Cartman.config.redis.exists("cartman:cart:1").should be_false
-        Cartman.config.redis.exists("cartman:line_item:1").should be_false
-        Cartman.config.redis.exists("cartman:line_item:2").should be_false
-        Cartman.config.redis.exists("cartman:cart:1:index").should be_false
-        Cartman.config.redis.exists("cartman:cart:1:index:Bottle:17").should be_false
+        Cartman.config.redis.exists("cartman:cart:1").should be_falsey
+        Cartman.config.redis.exists("cartman:line_item:1").should be_falsey
+        Cartman.config.redis.exists("cartman:line_item:2").should be_falsey
+        Cartman.config.redis.exists("cartman:cart:1:index").should be_falsey
+        Cartman.config.redis.exists("cartman:cart:1:index:Bottle:17").should be_falsey
       end
     end
 
@@ -233,20 +245,20 @@ describe Cartman do
         cart.reassign(2)
         cart.items.size.should be(2)
         Cartman::Cart.new(2).quantity.should be(4)
-        Cartman.config.redis.exists("cartman:cart:1").should be_false
-        Cartman.config.redis.exists("cartman:cart:1:index").should be_false
-        Cartman.config.redis.exists("cartman:cart:1:index:Bottle:17").should be_false
-        Cartman.config.redis.exists("cartman:cart:2").should be_true
-        Cartman.config.redis.exists("cartman:cart:2:index").should be_true
-        Cartman.config.redis.exists("cartman:cart:2:index:Bottle:17").should be_true
+        Cartman.config.redis.exists("cartman:cart:1").should be_falsey
+        Cartman.config.redis.exists("cartman:cart:1:index").should be_falsey
+        Cartman.config.redis.exists("cartman:cart:1:index:Bottle:17").should be_falsey
+        Cartman.config.redis.exists("cartman:cart:2").should be_truthy
+        Cartman.config.redis.exists("cartman:cart:2:index").should be_truthy
+        Cartman.config.redis.exists("cartman:cart:2:index:Bottle:17").should be_truthy
         cart.send(:key)[-1].should eq("2")
         cart.add_item(id: 19, type: "Bottle", name: "Bordeux", unit_cost: 92.12, cost_in_cents: 18424, quantity: 2)
         cart.reassign(1)
         cart.items.size.should be(3)
-        Cartman.config.redis.exists("cartman:cart:2").should be_false
-        Cartman.config.redis.exists("cartman:cart:2:index").should be_false
-        Cartman.config.redis.exists("cartman:cart:1").should be_true
-        Cartman.config.redis.exists("cartman:cart:1:index").should be_true
+        Cartman.config.redis.exists("cartman:cart:2").should be_falsey
+        Cartman.config.redis.exists("cartman:cart:2:index").should be_falsey
+        Cartman.config.redis.exists("cartman:cart:1").should be_truthy
+        Cartman.config.redis.exists("cartman:cart:1:index").should be_truthy
         cart.send(:key)[-1].should eq("1")
       end
     end

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -42,8 +42,8 @@ describe Cartman do
       it "should remove the item from the cart" do
         item_id = item._id
         item.destroy
-        Cartman.config.redis.sismember(cart.send(:key), item_id).should be_false
-        Cartman.config.redis.exists("cartman:line_item:#{item_id}").should be_false
+        Cartman.config.redis.sismember(cart.send(:key), item_id).should be_falsey
+        Cartman.config.redis.exists("cartman:line_item:#{item_id}").should be_falsey
       end
     end
 
@@ -59,6 +59,5 @@ describe Cartman do
         item.cache_key.should eq("item/#{item._id}-#{item._version}")
       end
     end
-
   end
 end


### PR DESCRIPTION
We are getting a lot of errors indexed in datadog that there are deprecation errors for this library. The library hasn't been updated since 2014. If we decide to continue with it, we should probably do a larger redis version upgrade and syntax validation.